### PR TITLE
JP-279 hotfix... no idea what is the right way to solve that

### DIFF
--- a/config/fares/file/SUP.ts
+++ b/config/fares/file/SUP.ts
@@ -17,7 +17,7 @@ const supplement = new FixedWidthRecord(
     "description": new TextField(29, 20),
     "short_desc": new TextField(49, 12),
     "suppl_type": new TextField(61, 3),
-    "price": new IntField(64, 5),
+    "price": new IntField(64, 5, false, [" ", "*"]),
     "cpf_ticket_type": new TextField(69, 5, true),
     "min_group_size": new IntField(74, 1),
     "max_group_size": new IntField(75, 1),


### PR DESCRIPTION
I face the problem: 
`Error processing RJFAF024.SUP with data RSXSU311229990201201905122018BERTH SUPPLEMENT BERTH SUPP SLE99999 11L1ZWSY01 Error: Non-nullable field received null value: "99999" at position 64`

it has been thrown here:
https://github.com/planarnetwork/dtd2mysql/blob/d8f25ae30c8003156286f37f18eb91e78dd6654e/src/feed/field/Field.ts#L34

now, it has been considered as nullable because `nullChars` for that field is: `[" ", "*", "9"]`. I assume that we never meet such a case before.

It occur during processing `RJFAF024` package.