### PR TITLE
Remove pass times from the generated GTFS

### DIFF
--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -84,9 +84,9 @@ export class CIFRepository {
           schedule.id AS id, train_uid, retail_train_id, runs_from, runs_to,
           monday, tuesday, wednesday, thursday, friday, saturday, sunday,
           crs_code, stp_indicator, public_arrival_time, public_departure_time,
-          IF(train_status="S", "SS", train_category) AS train_category, 
-          IFNULL(scheduled_arrival_time, scheduled_pass_time) AS scheduled_arrival_time, 
-          IFNULL(scheduled_departure_time, scheduled_pass_time) AS scheduled_departure_time,
+          IF(train_status="S", "SS", train_category) AS train_category,
+          scheduled_arrival_time AS scheduled_arrival_time,
+          scheduled_departure_time AS scheduled_departure_time,
           platform, atoc_code, stop_time.id AS stop_id, activity, reservations, train_class
         FROM schedule
         LEFT JOIN schedule_extra ON schedule.id = schedule_extra.schedule
@@ -98,6 +98,7 @@ export class CIFRepository {
         )
         AND runs_from < CURDATE() + INTERVAL 3 MONTH
         AND runs_to >= CURDATE()
+        AND scheduled_pass_time is null
         ORDER BY stp_indicator DESC, id, stop_id
       `)),
       scheduleBuilder.loadSchedules(this.stream.query(`

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -98,16 +98,8 @@ export class ScheduleBuilder {
   private createStop(row: ScheduleStopTimeRow, stopId: number, departHour: number): StopTime {
     let arrivalTime, departureTime;
 
-    // if either public time is set, use those
-    if (row.public_arrival_time || row.public_departure_time) {
-      arrivalTime = this.formatTime(row.public_arrival_time, departHour);
-      departureTime = this.formatTime(row.public_departure_time, departHour);
-    }
-    // if no public time at all (no set down or pick) use the scheduled time
-    else {
-      arrivalTime = this.formatTime(row.scheduled_arrival_time, departHour);
-      departureTime = this.formatTime(row.scheduled_departure_time, departHour);
-    }
+    arrivalTime = this.formatTime(row.public_arrival_time ?? row.scheduled_arrival_time, departHour);
+    departureTime = this.formatTime(row.public_departure_time ?? row.scheduled_departure_time, departHour);
 
     const activities = row.activity.match(/.{1,2}/g) || [];
     const pickup = pickupActivities.find(a => activities.includes(a)) && !activities.includes(notAdvertised) ? 0 : 1;

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -98,8 +98,16 @@ export class ScheduleBuilder {
   private createStop(row: ScheduleStopTimeRow, stopId: number, departHour: number): StopTime {
     let arrivalTime, departureTime;
 
-    arrivalTime = this.formatTime(row.public_arrival_time ?? row.scheduled_arrival_time, departHour);
-    departureTime = this.formatTime(row.public_departure_time ?? row.scheduled_departure_time, departHour);
+    // if either public time is set, use those
+    if (row.public_arrival_time || row.public_departure_time) {
+      arrivalTime = this.formatTime(row.public_arrival_time, departHour);
+      departureTime = this.formatTime(row.public_departure_time, departHour);
+    }
+    // if no public time at all (no set down or pick) use the scheduled time
+    else {
+      arrivalTime = this.formatTime(row.scheduled_arrival_time, departHour);
+      departureTime = this.formatTime(row.scheduled_departure_time, departHour);
+    }
 
     const activities = row.activity.match(/.{1,2}/g) || [];
     const pickup = pickupActivities.find(a => activities.includes(a)) && !activities.includes(notAdvertised) ? 0 : 1;


### PR DESCRIPTION
The generated GTFS have pass times included as stop times which are factually wrong. They are removed in the pull request.

Unadvertised stops remain as stops in the GTFS.