### PR TITLE
Do not catch error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,4 @@ const container = new Container();
 
 container
   .getCommand(process.argv[2])
-  .then(c => c.run(process.argv))
-  .catch(console.error);
+  .then(c => c.run(process.argv));


### PR DESCRIPTION
The catch method hides exception from the data loader. Exceptions should not be caught such that the script crashes when there is a problem, in order for pipelines to work correctly.