### PR TITLE
restore type safety for queries

### DIFF
--- a/src/cli/CleanFaresCommand.ts
+++ b/src/cli/CleanFaresCommand.ts
@@ -75,7 +75,7 @@ export class CleanFaresCommand implements CLICommand {
   }
 
   private async applyRestrictionDates(): Promise<void> {
-    const [[current, future]] = await this.db.query<RestrictionDateRow[]>("SELECT * FROM restriction_date ORDER BY cf_mkr");
+    const [[current, future]] = await this.db.query<RestrictionDateRow>("SELECT * FROM restriction_date ORDER BY cf_mkr");
     current.start_date = new Date(current.start_date.getFullYear(), 0, 1);
 
     future.start_date = new Date(future.start_date.getFullYear(), 0, 1);
@@ -85,7 +85,7 @@ export class CleanFaresCommand implements CLICommand {
   }
 
   private async updateRestrictionDatesOnTable(tableName: string, current: RestrictionDateRow, future: RestrictionDateRow): Promise<any> {
-    const [records] = await this.db.query<RestrictionRow[]>(`SELECT * FROM ${tableName}`);
+    const [records] = await this.db.query<RestrictionRow>(`SELECT * FROM ${tableName}`);
     const promises = records.map(record => {
       const date = record.cf_mkr === 'C' ? current : future;
       const startDate = this.getFirstDateAfter(date.start_date, record.date_from);

--- a/src/cli/DownloadCommand.ts
+++ b/src/cli/DownloadCommand.ts
@@ -3,6 +3,12 @@ import {PromiseSFTP} from "../sftp/PromiseSFTP";
 import {DatabaseConnection} from "../database/DatabaseConnection";
 import { FileEntry } from "ssh2";
 
+interface LogEntry {
+  id: number,
+  filename: string | null,
+  processed: string | null,
+}
+
 export class DownloadCommand implements CLICommand {
 
   constructor(
@@ -46,9 +52,9 @@ export class DownloadCommand implements CLICommand {
 
   private async getLastProcessedFile(): Promise<string | undefined> {
     try {
-      const [[log]] = await this.db.query("SELECT * FROM log ORDER BY id DESC LIMIT 1");
+      const [[log]] = await this.db.query<LogEntry>("SELECT * FROM log ORDER BY id DESC LIMIT 1");
 
-      return log ? log.filename : undefined;
+      return log.filename !== null ? log.filename : undefined;
     }
     catch (err) {
       return undefined;

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -91,14 +91,14 @@ export class ImportFeedCommand implements CLICommand {
   /**
    * Create the last_file table (if it doesn't already exist)
    */
-  private async createLastProcessedSchema(): Promise<void> {
-    await this.db.query(`
+  private createLastProcessedSchema(): Promise<void> {
+    return this.db.query(`
       CREATE TABLE IF NOT EXISTS log ( 
         id INT(11) unsigned not null primary key auto_increment, 
         filename VARCHAR(255), 
         processed DATETIME 
       )
-    `);
+    `).then((_) => {});
   }
 
   /**
@@ -121,8 +121,8 @@ export class ImportFeedCommand implements CLICommand {
   }
 
 
-  private async updateLastFile(filename: string): Promise<void> {
-    await this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]);
+  private updateLastFile(filename: string): Promise<void> {
+    return this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]).then((_) => {});
   }
 
   /**

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -91,14 +91,14 @@ export class ImportFeedCommand implements CLICommand {
   /**
    * Create the last_file table (if it doesn't already exist)
    */
-  private createLastProcessedSchema(): Promise<void> {
-    return this.db.query(`
+  private async createLastProcessedSchema(): Promise<void> {
+    await this.db.query(`
       CREATE TABLE IF NOT EXISTS log ( 
         id INT(11) unsigned not null primary key auto_increment, 
         filename VARCHAR(255), 
         processed DATETIME 
       )
-    `).then((_) => {});
+    `);
   }
 
   /**
@@ -121,8 +121,8 @@ export class ImportFeedCommand implements CLICommand {
   }
 
 
-  private updateLastFile(filename: string): Promise<void> {
-    return this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]).then((_) => {});
+  private async updateLastFile(filename: string): Promise<void> {
+    await this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]);
   }
 
   /**

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -105,7 +105,7 @@ export class ImportFeedCommand implements CLICommand {
    * Set the last schedule ID in the CFA record
    */
   private async setLastScheduleId(): Promise<void> {
-    const [[lastSchedule]] = await this.db.query("SELECT id FROM schedule ORDER BY id desc LIMIT 1");
+    const [[lastSchedule]] = await this.db.query<{id : number}>("SELECT id FROM schedule ORDER BY id desc LIMIT 1");
     const lastId = lastSchedule ? lastSchedule.id : 0;
     const cfaFile = this.files["CFA"] as MultiRecordFile;
     const bsRecord = cfaFile.records["BS"] as RecordWithManualIdentifier;

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -91,8 +91,8 @@ export class ImportFeedCommand implements CLICommand {
   /**
    * Create the last_file table (if it doesn't already exist)
    */
-  private createLastProcessedSchema(): Promise<void> {
-    return this.db.query(`
+  private async createLastProcessedSchema(): Promise<void> {
+    await this.db.query(`
       CREATE TABLE IF NOT EXISTS log ( 
         id INT(11) unsigned not null primary key auto_increment, 
         filename VARCHAR(255), 
@@ -121,8 +121,8 @@ export class ImportFeedCommand implements CLICommand {
   }
 
 
-  private updateLastFile(filename: string): Promise<void> {
-    return this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]);
+  private async updateLastFile(filename: string): Promise<void> {
+    await this.db.query("INSERT INTO log VALUES (null, ?, NOW())", [filename]);
   }
 
   /**

--- a/src/database/DatabaseConnection.ts
+++ b/src/database/DatabaseConnection.ts
@@ -1,7 +1,7 @@
 
 export interface DatabaseConnection {
   getConnection(): Promise<DatabaseConnection>;
-  query<T = void>(sql: any, parameters?: any[]): any;
+  query<RowType = any>(sql: any, parameters?: any[]): Promise<[RowType[], any]>;
   end(): Promise<void>;
   release(): Promise<void>;
 }

--- a/src/database/DatabaseConnection.ts
+++ b/src/database/DatabaseConnection.ts
@@ -1,7 +1,7 @@
 
 export interface DatabaseConnection {
   getConnection(): Promise<DatabaseConnection>;
-  query<RowType = any>(sql: any, parameters?: any[]): Promise<[RowType[], any]>;
+  query<RowType = unknown>(sql: any, parameters?: any[]): Promise<[RowType[], any]>;
   end(): Promise<void>;
   release(): Promise<void>;
 }

--- a/src/database/MySQLTable.ts
+++ b/src/database/MySQLTable.ts
@@ -83,17 +83,20 @@ export class MySQLTable {
     }
   }
 
-  private query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
+  private async query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
     const rowValues = rows.map(r => Object.values(r.values));
 
     switch (type) {
       case RecordAction.Insert:
       case RecordAction.DelayedInsert:
-        return this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]).then((_) => {});
+        await this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        return;
       case RecordAction.Update:
-        return this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]).then((_) => {});
+        await this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        return;
       case RecordAction.Delete:
-        return this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues))).then((_) => {});
+        await this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues)));
+        return;
       default:
         throw new Error("Unknown record action: " + type);
     }

--- a/src/database/MySQLTable.ts
+++ b/src/database/MySQLTable.ts
@@ -83,20 +83,17 @@ export class MySQLTable {
     }
   }
 
-  private async query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
+  private query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
     const rowValues = rows.map(r => Object.values(r.values));
 
     switch (type) {
       case RecordAction.Insert:
       case RecordAction.DelayedInsert:
-        await this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
-        return;
+        return this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]).then((_) => {});
       case RecordAction.Update:
-        await this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
-        return;
+        return this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]).then((_) => {});
       case RecordAction.Delete:
-        await this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues)));
-        return;
+        return this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues))).then((_) => {});
       default:
         throw new Error("Unknown record action: " + type);
     }

--- a/src/database/MySQLTable.ts
+++ b/src/database/MySQLTable.ts
@@ -83,17 +83,20 @@ export class MySQLTable {
     }
   }
 
-  private query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
+  private async query(type: RecordAction, rows: ParsedRecord[]): Promise<void> {
     const rowValues = rows.map(r => Object.values(r.values));
 
     switch (type) {
       case RecordAction.Insert:
       case RecordAction.DelayedInsert:
-        return this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        await this.db.query(`INSERT IGNORE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        return;
       case RecordAction.Update:
-        return this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        await this.db.query(`REPLACE INTO \`${this.tableName}\` VALUES ?`, [rowValues]);
+        return;
       case RecordAction.Delete:
-        return this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues)));
+        await this.db.query(`DELETE FROM \`${this.tableName}\` WHERE (${this.getDeleteSQL(rows)})`, rows.flatMap(row => Object.values(row.keysValues)));
+        return;
       default:
         throw new Error("Unknown record action: " + type);
     }

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -88,7 +88,7 @@ export class CIFRepository {
    */
   public async getSchedules(): Promise<ScheduleResults> {
     const scheduleBuilder = new ScheduleBuilder();
-    const [[lastSchedule]] = await this.db.query("SELECT id FROM schedule ORDER BY id desc LIMIT 1");
+    const [[lastSchedule]] = await this.db.query<{id: number}>("SELECT id FROM schedule ORDER BY id desc LIMIT 1");
 
     await Promise.all([
       scheduleBuilder.loadSchedules(this.stream.query(`

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -29,7 +29,7 @@ export class CIFRepository {
    * Return the interchange time between each station
    */
   public async getTransfers(): Promise<Transfer[]> {
-    const [results] = await this.db.query<Transfer[]>(`
+    const [results] = await this.db.query<Transfer>(`
       SELECT 
         crs_code AS from_stop_id, 
         crs_code AS to_stop_id, 
@@ -136,7 +136,7 @@ export class CIFRepository {
    * Get associations
    */
   public async getAssociations(): Promise<Association[]> {
-    const [results] = await this.db.query<AssociationRow[]>(`
+    const [results] = await this.db.query<AssociationRow>(`
       SELECT 
         a.id AS id, base_uid, assoc_uid, crs_code, assoc_date_ind, assoc_cat,
         monday, tuesday, wednesday, thursday, friday, saturday, sunday,


### PR DESCRIPTION
A while ago the query method was made always returning `any` regardless of the type parameter. This pull request restores how it was intended to work.