### PR TITLE
fix Typescript delete must be on optional error

### DIFF
--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -67,9 +67,8 @@ export class CIFRepository {
     // overlay the long and latitude values from configuration
     return results.map(row => {
       const [stop_lon, stop_lat] = proj4('EPSG:27700', 'EPSG:4326', [(row.easting - 10000) * 100, (row.northing - 60000) * 100]);
-      // @ts-ignore We are overwriting the lon/lat from this.stationCoordinates
-      const {easting, northing, ...stop} = {...row, stop_lon, stop_lat, ...this.stationCoordinates[row.stop_id]};
-      return stop;
+      const {easting, northing, ...stop} = {...row, stop_lon, stop_lat};
+      return Object.assign(stop, this.stationCoordinates[stop.stop_id]);
     });
   }
 

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -46,14 +46,12 @@ export class CIFRepository {
    * Return all the stops with some configurable long/lat applied
    */
   public async getStops(): Promise<Stop[]> {
-    const [results] = await this.db.query<(Stop & {easting : number, northing : number})>(`
+    const [results] = await this.db.query<Omit<Stop, 'stop_lat' | 'stop_lon'> & {easting : number, northing : number}>(`
       SELECT
         crs_code AS stop_id, 
         tiploc_code AS stop_code,
         station_name AS stop_name,
         cate_interchange_status AS stop_desc,
-        0 AS stop_lat,
-        0 AS stop_lon,
         NULL AS zone_id,
         NULL AS stop_url,
         NULL AS location_type,

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -67,8 +67,9 @@ export class CIFRepository {
     // overlay the long and latitude values from configuration
     return results.map(row => {
       const [stop_lon, stop_lat] = proj4('EPSG:27700', 'EPSG:4326', [(row.easting - 10000) * 100, (row.northing - 60000) * 100]);
-      const {easting, northing, ...stop} = {...row, stop_lon, stop_lat};
-      return Object.assign(stop, this.stationCoordinates[stop.stop_id]);
+      // @ts-ignore We are overwriting the lon/lat from this.stationCoordinates
+      const {easting, northing, ...stop} = {...row, stop_lon, stop_lat, ...this.stationCoordinates[row.stop_id]};
+      return stop;
     });
   }
 

--- a/src/gtfs/repository/CIFRepository.ts
+++ b/src/gtfs/repository/CIFRepository.ts
@@ -67,12 +67,9 @@ export class CIFRepository {
     `);
 
     // overlay the long and latitude values from configuration
-    return results.map(stop => {
-      const [stop_lon, stop_lat] = proj4('EPSG:27700', 'EPSG:4326', [(stop.easting - 10000) * 100, (stop.northing - 60000) * 100]);
-      stop.stop_lon = stop_lon;
-      stop.stop_lat = stop_lat;
-      delete stop.easting;
-      delete stop.northing;
+    return results.map(row => {
+      const [stop_lon, stop_lat] = proj4('EPSG:27700', 'EPSG:4326', [(row.easting - 10000) * 100, (row.northing - 60000) * 100]);
+      const {easting, northing, ...stop} = {...row, stop_lon, stop_lat};
       return Object.assign(stop, this.stationCoordinates[stop.stop_id]);
     });
   }


### PR DESCRIPTION
I'm sorry, the code in #87 to introduce type safety has uncovered a type error in #88 . I didn't realise that the `delete` operator must only be used on optional properties, and the code now no longer runs.

This rewrites the method to avoid mutation, but transformation instead.