### PR TITLE
fix DST change issues

### DIFF
--- a/src/gtfs/command/AddLateNightServices.ts
+++ b/src/gtfs/command/AddLateNightServices.ts
@@ -2,13 +2,19 @@ import {Schedule} from "../native/Schedule";
 import {IdGenerator} from "../native/OverlayRecord";
 
 /**
- * Loop through every schedule and add a copy of any early morning services to the previous day.
+ * Loop through every schedule and replace any early morning services with a copy on the previous day.
+ *
+ * GTFS specification defines "time" as starting from noon minus 12 hours, which is normally midnight
+ * but may be different by 1 hour on the day when the summer time zone changes, in order to avoid
+ * a DST change happening inside a service day.
+ *
+ * Therefore, trains which depart before the change on changeover days should be recorded as on the
+ * previous service day instead.
  */
 export function addLateNightServices(schedules: Schedule[], idGenerator: IdGenerator): Schedule[] {
   const result: Schedule[] = [];
 
   for (const schedule of schedules) {
-    result.push(schedule);
     const departureHour = parseInt(schedule.stopTimes[0].departure_time.substr(0, 2), 10);
 
     if (departureHour <= 1) {
@@ -20,6 +26,8 @@ export function addLateNightServices(schedules: Schedule[], idGenerator: IdGener
       }
 
       result.push(newSchedule);
+    } else {
+      result.push(schedule);
     }
   }
 

--- a/test/gtfs/command/AddLateNightServices.spec.ts
+++ b/test/gtfs/command/AddLateNightServices.spec.ts
@@ -24,19 +24,17 @@ describe("AddLateNightServices", () => {
 
     const schedules = addLateNightServices(baseSchedules, idGenerator());
 
-    chai.expect(schedules[0].calendar.runsFrom.isSame("20181001")).to.be.true;
-    chai.expect(schedules[0].calendar.runsTo.isSame("20181031")).to.be.true;
-    chai.expect(schedules[1].calendar.runsFrom.isSame("20180930")).to.be.true;
-    chai.expect(schedules[1].calendar.runsTo.isSame("20181030")).to.be.true;
-    chai.expect(schedules[1].calendar.days[0]).to.equal(1);
-    chai.expect(schedules[1].calendar.days[1]).to.equal(1);
-    chai.expect(schedules[1].calendar.days[2]).to.equal(1);
-    chai.expect(schedules[1].calendar.days[3]).to.equal(1);
-    chai.expect(schedules[1].calendar.days[4]).to.equal(0);
-    chai.expect(schedules[1].calendar.days[5]).to.equal(0);
-    chai.expect(schedules[1].calendar.days[6]).to.equal(1);
-    chai.expect(schedules[2].calendar.runsFrom.isSame("20181001")).to.be.true;
-    chai.expect(schedules[2].calendar.runsTo.isSame("20181031")).to.be.true;
+    chai.expect(schedules[0].calendar.runsFrom.isSame("20180930")).to.be.true;
+    chai.expect(schedules[0].calendar.runsTo.isSame("20181030")).to.be.true;
+    chai.expect(schedules[0].calendar.days[0]).to.equal(1);
+    chai.expect(schedules[0].calendar.days[1]).to.equal(1);
+    chai.expect(schedules[0].calendar.days[2]).to.equal(1);
+    chai.expect(schedules[0].calendar.days[3]).to.equal(1);
+    chai.expect(schedules[0].calendar.days[4]).to.equal(0);
+    chai.expect(schedules[0].calendar.days[5]).to.equal(0);
+    chai.expect(schedules[0].calendar.days[6]).to.equal(1);
+    chai.expect(schedules[1].calendar.runsFrom.isSame("20181001")).to.be.true;
+    chai.expect(schedules[1].calendar.runsTo.isSame("20181031")).to.be.true;
   });
 
 });


### PR DESCRIPTION
The GTFS specifications specifies that the time is defined as starting from noon minus 12 hours, in order to avoid a DST change happening on a service day. Therefore, trains departing before the DST change, i.e. 02:00, should be considered part of the previous service day in GTFS:

* A train scheduled to depart 01:05 on March changeover day will run on GMT for its whole journey, while a train scheduled to depart 02:05 will run on BST.
* A train scheduled to depart 01:05 on October changeover day will run on BST for its whole journey, while a train scheduled to depart 02:05 will run on GMT.

This doesn't have any special handling on skipped / additional trains in the skipped / additional hour on the Night Overground services, which the handling is yet to be confirmed.

Fixes #86 .