### PR TITLE
Fix invalid gtfs file caused by agencies not in hardcoded list

### DIFF
--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -5,6 +5,7 @@ import moment = require("moment");
 import {ScheduleCalendar} from "../native/ScheduleCalendar";
 import {ScheduleStopTimeRow} from "./CIFRepository";
 import {StopTime} from "../file/StopTime";
+import { agencies } from "../../../config/gtfs/agency";
 
 const pickupActivities = ["T ", "TB", "U "];
 const dropOffActivities = ["T ", "TF", "D "];
@@ -88,7 +89,7 @@ export class ScheduleBuilder {
         }
       ),
       mode,
-      row.atoc_code,
+      agencies.some((a) => a.agency_id === row.atoc_code) ? row.atoc_code : "ZZ",
       row.stp_indicator,
       mode === RouteType.Rail && row.train_class !== "S",
       row.reservations !== null


### PR DESCRIPTION
Inputting a timetable from the [national rail data portal](https://wiki.openraildata.com/index.php?title=National_Rail_Data_Portal) I get an error when importing into OpenTransitPlanner: `could not find Agency with specified id=QV for route <Route null null>`

I believe OpenTransitPlanner is correct here because [the GTFS validator agress the file is invalid](https://gtfs-validator-results.mobilitydata.org/e89d8df0-4f81-4bdf-b007-b7e5bb6803d1/report).

The routes.txt contains routes with agency id QH, QR, QU, and QV. Per [openraildata](https://wiki.openraildata.com/index.php/TOC_Codes) these are network rail business codes for Anglia, North West & Central, Wales & Western, and East Midlands. One example is the "QR boat service from STQ to STQ". This appears to be [the ferry from Southampton to the Isle of Wight](https://www.southwesternrailway.com/train-tickets/combined-ferry-and-train-tickets) operated by South Western. I have no idea why it isn't under their code.

At least in this specific table all the routes are by bus or boat.

The simplest solution I can think of would be to omit the operator code for operators not in the hardcoded agencies list. That way they will be exported with the existing 'ZZ' - Other operator code.