### PR TITLE
Do not catch errors when importing feed

### DIFF
--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -36,12 +36,7 @@ export class ImportFeedCommand implements CLICommand {
    * Do the import and then shut down the connection pool
    */
   public async run(argv: string[]): Promise<void> {
-    try {
-      await this.doImport(argv[3]);
-    }
-    catch (err) {
-      console.error(err);
-    }
+    await this.doImport(argv[3]);
 
     return this.end();
   }


### PR DESCRIPTION
The program should crash when importing feed fails such that build pipelines can behave properly.