### PR TITLE
use unique temp directory

### DIFF
--- a/src/cli/Container.ts
+++ b/src/cli/Container.ts
@@ -1,4 +1,7 @@
 import * as memoize from "memoized-class-decorator";
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {CLICommand} from "./CLICommand";
 import {ImportFeedCommand} from "./ImportFeedCommand";
 import {DatabaseConfiguration, DatabaseConnection} from "../database/DatabaseConnection";
@@ -45,22 +48,22 @@ export class Container {
 
   @memoize
   public async getFaresImportCommand(): Promise<ImportFeedCommand> {
-    return new ImportFeedCommand(await this.getDatabaseConnection(), config.fares, "/tmp/dtd/fares/");
+    return new ImportFeedCommand(await this.getDatabaseConnection(), config.fares, fs.mkdtempSync(path.join(os.tmpdir(), "dtd")));
   }
 
   @memoize
   public async getRouteingImportCommand(): Promise<ImportFeedCommand> {
-    return new ImportFeedCommand(await this.getDatabaseConnection(), config.routeing, "/tmp/dtd/routeing/");
+    return new ImportFeedCommand(await this.getDatabaseConnection(), config.routeing, fs.mkdtempSync(path.join(os.tmpdir(), "dtd")));
   }
 
   @memoize
   public async getTimetableImportCommand(): Promise<ImportFeedCommand> {
-    return new ImportFeedCommand(await this.getDatabaseConnection(), config.timetable, "/tmp/dtd/timetable/");
+    return new ImportFeedCommand(await this.getDatabaseConnection(), config.timetable, fs.mkdtempSync(path.join(os.tmpdir(), "dtd")));
   }
 
   @memoize
   public async getNFM64ImportCommand(): Promise<ImportFeedCommand> {
-    return new ImportFeedCommand(await this.getDatabaseConnection(), config.nfm64, "/tmp/dtd/nfm64/");
+    return new ImportFeedCommand(await this.getDatabaseConnection(), config.nfm64, fs.mkdtempSync(path.join(os.tmpdir(), "dtd")));
   }
 
 

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -132,7 +132,7 @@ export class ImportFeedCommand implements CLICommand {
     const file = this.getFeedFile(filename);
     const tables = await this.tables(file);
     const tableStream = new MySQLStream(filename, file, tables);
-    const stream = readFile(this.tmpFolder + filename).pipe(tableStream);
+    const stream = readFile(`${this.tmpFolder}/${filename}`).pipe(tableStream);
 
     try {
       await streamToPromise(stream);

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -25,7 +25,7 @@ export class OutputGTFSCommand implements CLICommand {
    * Turn the timetable feed into GTFS files
    */
   public async run(argv: string[]): Promise<void> {
-    this.baseDir = argv[3] || "./";
+    this.baseDir = argv[3] || ".";
 
     if (!fs.existsSync(this.baseDir)) {
       throw new Error(`Output path ${this.baseDir} does not exist.`);
@@ -63,7 +63,7 @@ export class OutputGTFSCommand implements CLICommand {
    */
   private async copy(results: object[] | Promise<object[]>, filename: string): Promise<void> {
     const rows = await results;
-    const output = this.output.open(this.baseDir + filename);
+    const output = this.output.open(`${this.baseDir}/filename`);
 
     console.log("Writing " + filename);
     rows.forEach(row => output.write(row));
@@ -77,9 +77,9 @@ export class OutputGTFSCommand implements CLICommand {
    */
   private copyTrips(schedules: Schedule[], serviceIds: ServiceIdIndex): Promise<any> {
     console.log("Writing trips.txt, stop_times.txt and routes.txt");
-    const trips = this.output.open(this.baseDir + "trips.txt");
-    const stopTimes = this.output.open(this.baseDir + "stop_times.txt");
-    const routeFile = this.output.open(this.baseDir + "routes.txt");
+    const trips = this.output.open(`${this.baseDir}/trips.txt`);
+    const stopTimes = this.output.open(`${this.baseDir}/stop_times.txt`);
+    const routeFile = this.output.open(`${this.baseDir}/routes.txt`);
     const routes = {};
 
     for (const schedule of schedules) {

--- a/src/cli/OutputGTFSZipCommand.ts
+++ b/src/cli/OutputGTFSZipCommand.ts
@@ -1,4 +1,6 @@
 
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {CLICommand} from "./CLICommand";
 import {OutputGTFSCommand} from "./OutputGTFSCommand";
 import * as fs from "fs";
@@ -19,12 +21,8 @@ export class OutputGTFSZipCommand implements CLICommand {
     if (fs.existsSync(filename)) {
       fs.unlinkSync(filename);
     }
-
-    argv[3] = "/tmp/gtfs/";
-
-    if (!fs.existsSync(argv[3])) {
-      fs.mkdirSync(argv[3]);
-    }
+    
+    argv[3] = fs.mkdtempSync(path.join(os.tmpdir(), "gtfs"));
 
     await this.command.run(argv);
 


### PR DESCRIPTION
This supercedes #96 and also allows multiple instances of dtd2mysql to be run against different databases and/or data files as well.

Also, don't hardcode `tmp` as it gives undesirable results if run on Windows.