### PR TITLE
remove tmp directory upon successful processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "adm-zip": "^0.5.10",
         "byline": "^5.0.0",
         "csv-write-stream": "^2.0.0",
-        "fs-extra": "^11.1.1",
         "memoized-class-decorator": "^1.6.1",
         "moment": "^2.29.4",
         "mysql2": "^3.6.1",
@@ -27,7 +26,6 @@
       "devDependencies": {
         "@types/byline": "^4.2.33",
         "@types/chai": "^4.3.6",
-        "@types/fs-extra": "^11.0.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.11.6",
         "@types/ssh2": "^1.11.13",
@@ -38,7 +36,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": "^14.0.0"
+        "node": "^14.14.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -116,25 +114,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
       "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
       "dev": true
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
@@ -661,19 +640,6 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -758,11 +724,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -912,17 +873,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1528,14 +1478,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "adm-zip": "^0.5.10",
     "byline": "^5.0.0",
     "csv-write-stream": "^2.0.0",
-    "fs-extra": "^11.1.1",
     "memoized-class-decorator": "^1.6.1",
     "moment": "^2.29.4",
     "mysql2": "^3.6.1",
@@ -53,12 +52,11 @@
     "stream-to-promise": "^3.0.0"
   },
   "engines": {
-    "node": "^14.0.0"
+    "node": "^14.14.0"
   },
   "devDependencies": {
     "@types/byline": "^4.2.33",
     "@types/chai": "^4.3.6",
-    "@types/fs-extra": "^11.0.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.11.6",
     "@types/ssh2": "^1.11.13",

--- a/src/cli/ImportFeedCommand.ts
+++ b/src/cli/ImportFeedCommand.ts
@@ -1,4 +1,5 @@
 import AdmZip = require("adm-zip");
+import * as fs from 'fs';
 import {CLICommand} from "./CLICommand";
 import {FeedConfig} from "../../config";
 import {FeedFile} from "../feed/file/FeedFile";
@@ -7,7 +8,6 @@ import {DatabaseConnection} from "../database/DatabaseConnection";
 import * as path from "path";
 import {MySQLTable} from "../database/MySQLTable";
 import * as memoize from "memoized-class-decorator";
-import fs = require("fs-extra");
 import {MultiRecordFile} from "../feed/file/MultiRecordFile";
 import {RecordWithManualIdentifier} from "../feed/record/FixedWidthRecord";
 import {MySQLStream, TableIndex} from "../database/MySQLStream";
@@ -46,7 +46,7 @@ export class ImportFeedCommand implements CLICommand {
    */
   public async doImport(filePath: string): Promise<void> {
     console.log(`Extracting ${filePath} to ${this.tmpFolder}`);
-    fs.emptyDirSync(this.tmpFolder);
+    fs.rmSync(this.tmpFolder, {recursive: true, force: true});
 
     new AdmZip(filePath).extractAllTo(this.tmpFolder);
 
@@ -73,6 +73,7 @@ export class ImportFeedCommand implements CLICommand {
     }
 
     await this.updateLastFile(zipName);
+    fs.rmSync(this.tmpFolder, { recursive: true });
   }
 
   /**

--- a/src/cli/OutputGTFSZipCommand.ts
+++ b/src/cli/OutputGTFSZipCommand.ts
@@ -30,6 +30,7 @@ export class OutputGTFSZipCommand implements CLICommand {
     setTimeout(() => {
       console.log("Writing " + filename);
       processSpawnResult(spawnSync('zip', ['-jr', filename, argv[3]]));
+      fs.rmSync(argv[3], {recursive: true});
     }, 1000);
   }
 


### PR DESCRIPTION
dtd2mysql has never removed temporary files in the past, however, the change of #99 to allow multiple copies running simultaneously means that every run a new folder is created, and it can result in filling up disk space if the `/tmp` is never cleaned.

This change removes the created temporary folder when the command is successful. It requires bumping Node version from 14.0 to 14.14 , and `fs-extra` is no longer needed.